### PR TITLE
Add　swerve_visualizer

### DIFF
--- a/docs/visualization/natto_visualization_converter.md
+++ b/docs/visualization/natto_visualization_converter.md
@@ -126,3 +126,39 @@ speed_path_visualizer ノードは、natto_msgs/msg/SpeedPath メッセージを
 | トピック名 | メッセージ型 | 説明 |
 | - | - | - |
 | speed_path | natto_msgs/msg/SpeedPath | スピードパスデータ |
+
+
+# steering_vector_visualizer
+steering_vector_visualizer ノードは、`command_joint_states` を受信し、swerve シャーシの各ホイールの向きと速度をベクトルとして可視化します。
+
+## 機能
+- `chassis_calculator` と同じパラメータ名で swerve 用の設定を受け取る
+- 各ホイールのステア角と車輪速度から、長さ付きの矢印を生成
+- 連続する `command_joint_states` のステア角差分を 5 サンプル平均し、車体前方 0° を始点にした円弧状ステア速マーカーを生成
+- `visualization_msgs/msg/MarkerArray` としてパブリッシュ
+- RViz では `/visualization/steering_vector` の `MarkerArray` ディスプレイで確認できる
+
+## パラメーター
+| パラメーター名 | 型 | デフォルト値 | 説明 |
+| - | - | - | - |
+| chassis_type | string | "" | シャーシタイプ（`swerve` のみ対応） |
+| wheel_radius | double | 0.05 | ホイール半径（m）。回転速度を表示長に変換するために使用 |
+| wheel_names | string[] | {""} | ホイールジョイント名のリスト |
+| wheel_base_names | string[] | {""} | ホイールベースジョイント名のリスト |
+| infinite_swerve_mode | bool | false | `chassis_calculator` 互換のための設定 |
+| frequency | double | 100.0 | マーカー配列をパブリッシュする周期（Hz） |
+| frame_id | string | "command/base_link" | マーカーのフレームID |
+| line_width | double | 0.05 | 矢印の太さ |
+| vector_scale | double | 0.25 | 車輪速度に掛ける表示スケール |
+| rotation_vector_scale | double | 0.12 | 円弧の半径スケール |
+| rotation_vector_line_width | double | 0.03 | 円弧と矢印の線幅 |
+
+## パブリッシャー
+| トピック名 | メッセージ型 | 説明 |
+| - | - | - |
+| marker_array | visualization_msgs/msg/MarkerArray | 変換したステアベクトル |
+
+## サブスクライバー
+| トピック名 | メッセージ型 | 説明 |
+| - | - | - |
+| command_joint_states | sensor_msgs/msg/JointState | `chassis_calculator` の出力 |

--- a/map_builder/src/features/map-editor/components/MapView.tsx
+++ b/map_builder/src/features/map-editor/components/MapView.tsx
@@ -526,13 +526,15 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(
       } else {
         const path = buildArcPath(circle, viewport)
         if (path) {
+          const arcColor = isSelected ? "#ffd166" : "#e2a95f"
           arcElements.push(
             <path
               key={`${circle.id}-arc`}
               d={path}
-              stroke={isSelected ? '#ffd166' : '#e2a95f'}
+              stroke={arcColor}
               strokeWidth={isSelected ? 3 : 2.2}
               fill="none"
+              markerEnd={isSelected ? "url(#mapViewArcArrowSelected)" : "url(#mapViewArcArrow)"}
               onPointerDown={(event) => {
                 event.stopPropagation()
                 onSelectElement({ type: 'circle', circleId: circle.id })
@@ -604,6 +606,28 @@ export const MapView = forwardRef<MapViewHandle, MapViewProps>(
           onContextMenu={(event) => event.preventDefault()}
         >
           <defs>
+            <marker
+              id="mapViewArcArrow"
+              markerWidth={12}
+              markerHeight={12}
+              refX={10}
+              refY={6}
+              markerUnits="userSpaceOnUse"
+              orient="auto"
+            >
+              <path d="M 0 0 L 12 6 L 0 12 z" fill="#e2a95f" />
+            </marker>
+            <marker
+              id="mapViewArcArrowSelected"
+              markerWidth={12}
+              markerHeight={12}
+              refX={10}
+              refY={6}
+              markerUnits="userSpaceOnUse"
+              orient="auto"
+            >
+              <path d="M 0 0 L 12 6 L 0 12 z" fill="#ffd166" />
+            </marker>
             <pattern
               id="mapGrid"
               width={viewport.scale}

--- a/src/launch/natto_launch/launch/components/visualization.launch.xml
+++ b/src/launch/natto_launch/launch/components/visualization.launch.xml
@@ -31,6 +31,19 @@
             <remap from="marker_array" to="/visualization/speed_path"/>
             <param name="frame_id" value="map"/>
         </composable_node>
+
+        <!-- ステアベクトル表示 -->
+        <composable_node pkg="natto_visualization_converter" plugin="steering_vector_visualizer::steering_vector_visualizer" name="steering_vector" namespace="visualization/steering_vector">
+            <param from="$(var chassis_param_path)"/>
+            <param name="frequency" value="$(var fps)"/>
+            <param name="frame_id" value="command/base_link"/>
+            <param name="line_width" value="0.05"/>
+            <param name="vector_scale" value="0.25"/>
+            <param name="rotation_vector_scale" value="0.12"/>
+            <param name="rotation_vector_line_width" value="0.03"/>
+            <remap from="command_joint_states" to="/$(var chassis_type)/command_joint_states"/>
+            <remap from="marker_array" to="/visualization/steering_vector"/>
+        </composable_node>
     </node_container>
 
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
@@ -39,5 +52,5 @@
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
         args="-d $(var rviz_path)" unless="$(var use_dark_rviz)"/>
 
-    
+
 </launch>

--- a/src/launch/natto_launch/rviz/sample.rviz
+++ b/src/launch/natto_launch/rviz/sample.rviz
@@ -532,6 +532,17 @@ Visualization Manager:
             Reliability Policy: Reliable
             Value: /control/lookahead
           Value: true
+        - Class: rviz_default_plugins/MarkerArray
+          Enabled: true
+          Name: SteeringVector
+          Namespaces: {}
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /visualization/steering_vector
+          Value: true
       Enabled: true
       Name: Control
     - Class: rviz_common/Group

--- a/src/visualization/natto_visualization_converter/CMakeLists.txt
+++ b/src/visualization/natto_visualization_converter/CMakeLists.txt
@@ -29,6 +29,11 @@ rclcpp_components_register_node(${PROJECT_NAME}
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
+    PLUGIN "steering_vector_visualizer::steering_vector_visualizer"
+    EXECUTABLE steering_vector_visualizer
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
     PLUGIN "speed_path_visualizer::speed_path_visualizer"
     EXECUTABLE speed_path_visualizer
 )

--- a/src/visualization/natto_visualization_converter/include/natto_visualization_converter/swerve_visualizer.hpp
+++ b/src/visualization/natto_visualization_converter/include/natto_visualization_converter/swerve_visualizer.hpp
@@ -15,15 +15,15 @@
 #ifndef __STEERING_VECTOR_VISUALIZER_HPP__
 #define __STEERING_VECTOR_VISUALIZER_HPP__
 
-#include <string>
-#include <vector>
-
 #include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.hpp"
 #include "tf2_ros/transform_listener.hpp"
 
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
+
+#include <string>
+#include <vector>
 
 namespace steering_vector_visualizer {
 
@@ -32,25 +32,25 @@ class steering_vector_visualizer : public rclcpp::Node {
     explicit steering_vector_visualizer (const rclcpp::NodeOptions &options);
 
    private:
-    std::string             chassis_type_;
-    bool                    infinite_swerve_mode_;
-    double                  wheel_radius_;
-    std::string             frame_id_;
-    double                  line_width_;
-    double                  vector_scale_;
-    double                  rotation_vector_scale_;
-    double                  rotation_vector_line_width_;
-    std::vector<std::string> wheel_names_;
-    std::vector<std::string> wheel_base_names_;
-    sensor_msgs::msg::JointState joint_state_;
-    sensor_msgs::msg::JointState previous_joint_state_;
-    std::vector<double>         steering_speeds_;
-    std::vector<double>         steering_speed_average_;
+    std::string                      chassis_type_;
+    bool                             infinite_swerve_mode_;
+    double                           wheel_radius_;
+    std::string                      frame_id_;
+    double                           line_width_;
+    double                           vector_scale_;
+    double                           rotation_vector_scale_;
+    double                           rotation_vector_line_width_;
+    std::vector<std::string>         wheel_names_;
+    std::vector<std::string>         wheel_base_names_;
+    sensor_msgs::msg::JointState     joint_state_;
+    sensor_msgs::msg::JointState     previous_joint_state_;
+    std::vector<double>              steering_speeds_;
+    std::vector<double>              steering_speed_average_;
     std::vector<std::vector<double>> steering_speed_history_;
-    std::vector<size_t>         steering_speed_history_index_;
-    std::vector<size_t>         steering_speed_history_count_;
-    std::vector<int>            steering_speed_directions_;
-    bool                        has_previous_joint_state_ = false;
+    std::vector<size_t>              steering_speed_history_index_;
+    std::vector<size_t>              steering_speed_history_count_;
+    std::vector<int>                 steering_speed_directions_;
+    bool                             has_previous_joint_state_ = false;
 
     visualization_msgs::msg::MarkerArray marker_array_;
 
@@ -60,7 +60,7 @@ class steering_vector_visualizer : public rclcpp::Node {
     std::unique_ptr<tf2_ros::Buffer>            tf_buffer_;
     std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
-    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr     joint_state_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr      joint_state_sub_;
     rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
     rclcpp::TimerBase::SharedPtr                                       timer_;
 };

--- a/src/visualization/natto_visualization_converter/include/natto_visualization_converter/swerve_visualizer.hpp
+++ b/src/visualization/natto_visualization_converter/include/natto_visualization_converter/swerve_visualizer.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 Kazusa Hashimoto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __STEERING_VECTOR_VISUALIZER_HPP__
+#define __STEERING_VECTOR_VISUALIZER_HPP__
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/buffer.hpp"
+#include "tf2_ros/transform_listener.hpp"
+
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
+
+namespace steering_vector_visualizer {
+
+class steering_vector_visualizer : public rclcpp::Node {
+   public:
+    explicit steering_vector_visualizer (const rclcpp::NodeOptions &options);
+
+   private:
+    std::string             chassis_type_;
+    bool                    infinite_swerve_mode_;
+    double                  wheel_radius_;
+    std::string             frame_id_;
+    double                  line_width_;
+    double                  vector_scale_;
+    double                  rotation_vector_scale_;
+    double                  rotation_vector_line_width_;
+    std::vector<std::string> wheel_names_;
+    std::vector<std::string> wheel_base_names_;
+    sensor_msgs::msg::JointState joint_state_;
+    sensor_msgs::msg::JointState previous_joint_state_;
+    std::vector<double>         steering_speeds_;
+    std::vector<double>         steering_speed_average_;
+    std::vector<std::vector<double>> steering_speed_history_;
+    std::vector<size_t>         steering_speed_history_index_;
+    std::vector<size_t>         steering_speed_history_count_;
+    std::vector<int>            steering_speed_directions_;
+    bool                        has_previous_joint_state_ = false;
+
+    visualization_msgs::msg::MarkerArray marker_array_;
+
+    void joint_state_callback (const sensor_msgs::msg::JointState::SharedPtr msg);
+    void timer_callback ();
+
+    std::unique_ptr<tf2_ros::Buffer>            tf_buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr     joint_state_sub_;
+    rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
+    rclcpp::TimerBase::SharedPtr                                       timer_;
+};
+
+}  // namespace steering_vector_visualizer
+
+#endif  // __STEERING_VECTOR_VISUALIZER_HPP__

--- a/src/visualization/natto_visualization_converter/package.xml
+++ b/src/visualization/natto_visualization_converter/package.xml
@@ -19,6 +19,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2_sensor_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
 

--- a/src/visualization/natto_visualization_converter/src/swerve_visualizer.cpp
+++ b/src/visualization/natto_visualization_converter/src/swerve_visualizer.cpp
@@ -14,14 +14,15 @@
 
 #include "natto_visualization_converter/swerve_visualizer.hpp"
 
+#include "tf2/utils.hpp"
+
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <iterator>
 #include <stdexcept>
-
-#include "tf2/utils.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace steering_vector_visualizer {
 
@@ -39,9 +40,8 @@ double normalize_angle (double angle) {
     return std::atan2 (std::sin (angle), std::cos (angle));
 }
 
-std::vector<geometry_msgs::msg::Point> build_arc_points (
-    const geometry_msgs::msg::Point &center, double start_angle, double delta, double radius) {
-    const int segments = std::max (8, static_cast<int> (std::ceil (std::abs (delta) / (M_PI / 18.0))));
+std::vector<geometry_msgs::msg::Point> build_arc_points (const geometry_msgs::msg::Point &center, double start_angle, double delta, double radius) {
+    const int                              segments = std::max (8, static_cast<int> (std::ceil (std::abs (delta) / (M_PI / 18.0))));
     std::vector<geometry_msgs::msg::Point> points;
     points.reserve (static_cast<size_t> (segments) + 1);
 
@@ -62,16 +62,16 @@ std::vector<geometry_msgs::msg::Point> build_arc_points (
 }  // namespace
 
 steering_vector_visualizer::steering_vector_visualizer (const rclcpp::NodeOptions &options) : Node ("steering_vector_visualizer", options) {
-    marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray> ("marker_array", 10);
+    marker_pub_      = this->create_publisher<visualization_msgs::msg::MarkerArray> ("marker_array", 10);
     joint_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState> ("command_joint_states", rclcpp::SensorDataQoS (), std::bind (&steering_vector_visualizer::joint_state_callback, this, std::placeholders::_1));
 
-    double frequency      = this->declare_parameter<double> ("frequency", 100.0);
-    chassis_type_         = this->declare_parameter<std::string> ("chassis_type", "");
-    wheel_radius_         = this->declare_parameter<double> ("wheel_radius", 0.05);
-    wheel_names_          = this->declare_parameter<std::vector<std::string>> ("wheel_names", {""});
-    wheel_base_names_     = this->declare_parameter<std::vector<std::string>> ("wheel_base_names", {""});
-    infinite_swerve_mode_ = this->declare_parameter<bool> ("infinite_swerve_mode", false);
-    frame_id_             = this->declare_parameter<std::string> ("frame_id", "command/base_link");
+    double frequency            = this->declare_parameter<double> ("frequency", 100.0);
+    chassis_type_               = this->declare_parameter<std::string> ("chassis_type", "");
+    wheel_radius_               = this->declare_parameter<double> ("wheel_radius", 0.05);
+    wheel_names_                = this->declare_parameter<std::vector<std::string>> ("wheel_names", {""});
+    wheel_base_names_           = this->declare_parameter<std::vector<std::string>> ("wheel_base_names", {""});
+    infinite_swerve_mode_       = this->declare_parameter<bool> ("infinite_swerve_mode", false);
+    frame_id_                   = this->declare_parameter<std::string> ("frame_id", "command/base_link");
     line_width_                 = this->declare_parameter<double> ("line_width", 0.05);
     vector_scale_               = this->declare_parameter<double> ("vector_scale", 0.25);
     rotation_vector_scale_      = this->declare_parameter<double> ("rotation_vector_scale", 0.12);
@@ -112,33 +112,30 @@ steering_vector_visualizer::steering_vector_visualizer (const rclcpp::NodeOption
 void steering_vector_visualizer::joint_state_callback (const sensor_msgs::msg::JointState::SharedPtr msg) {
     // command_joint_states の連続差分を 5 サンプル平均して、低速域の符号反転を抑える。
     if (has_previous_joint_state_) {
-        const rclcpp::Time current_stamp  (msg->header.stamp);
+        const rclcpp::Time current_stamp (msg->header.stamp);
         const rclcpp::Time previous_stamp (previous_joint_state_.header.stamp);
-        const double       dt             = (current_stamp - previous_stamp).seconds ();
+        const double       dt = (current_stamp - previous_stamp).seconds ();
 
         if (dt > 1e-6) {
             constexpr double direction_threshold = 0.25;
-            constexpr size_t history_length = 5;
+            constexpr size_t history_length      = 5;
             for (size_t i = 0; i < wheel_base_names_.size (); ++i) {
                 const int current_idx  = find_index (msg->name, wheel_base_names_[i]);
                 const int previous_idx = find_index (previous_joint_state_.name, wheel_base_names_[i]);
 
-                if (
-                    current_idx < 0 || previous_idx < 0 ||
-                    static_cast<size_t> (current_idx) >= msg->position.size () ||
-                    static_cast<size_t> (previous_idx) >= previous_joint_state_.position.size ()) {
+                if (current_idx < 0 || previous_idx < 0 || static_cast<size_t> (current_idx) >= msg->position.size () || static_cast<size_t> (previous_idx) >= previous_joint_state_.position.size ()) {
                     continue;
                 }
 
-                const double current_angle = msg->position[static_cast<size_t> (current_idx)];
+                const double current_angle  = msg->position[static_cast<size_t> (current_idx)];
                 const double previous_angle = previous_joint_state_.position[static_cast<size_t> (previous_idx)];
                 const double raw_speed      = normalize_angle (current_angle - previous_angle) / dt;
 
                 steering_speeds_[i] = raw_speed;
 
-                auto &history = steering_speed_history_[i];
-                const size_t slot = steering_speed_history_index_[i];
-                history[slot] = raw_speed;
+                auto        &history             = steering_speed_history_[i];
+                const size_t slot                = steering_speed_history_index_[i];
+                history[slot]                    = raw_speed;
                 steering_speed_history_index_[i] = (slot + 1) % history_length;
                 steering_speed_history_count_[i] = std::min (steering_speed_history_count_[i] + 1, history_length);
 
@@ -178,7 +175,7 @@ void steering_vector_visualizer::timer_callback () {
     }
 
     for (size_t i = 0; i < wheel_names_.size (); ++i) {
-        const int wheel_idx     = find_index (joint_state_.name, wheel_names_[i]);
+        const int wheel_idx      = find_index (joint_state_.name, wheel_names_[i]);
         const int wheel_base_idx = find_index (joint_state_.name, wheel_base_names_[i]);
 
         if (wheel_idx < 0 || static_cast<size_t> (wheel_idx) >= joint_state_.velocity.size ()) {
@@ -240,12 +237,12 @@ void steering_vector_visualizer::timer_callback () {
             continue;
         }
 
-        const double steering_speed = steering_speed_average_[i];
-        const double speed_magnitude = std::max (std::abs (steering_speed), 0.35);
-        const double arc_radius = std::max (rotation_vector_scale_ * 1.8, rotation_vector_line_width_ * 5.0);
-        const double arc_delta   = std::clamp (speed_magnitude, 0.35, M_PI * 0.9);
+        const double steering_speed   = steering_speed_average_[i];
+        const double speed_magnitude  = std::max (std::abs (steering_speed), 0.35);
+        const double arc_radius       = std::max (rotation_vector_scale_ * 1.8, rotation_vector_line_width_ * 5.0);
+        const double arc_delta        = std::clamp (speed_magnitude, 0.35, M_PI * 0.9);
         const double signed_arc_delta = static_cast<double> (direction) * arc_delta;
-        const auto   arc_points = build_arc_points (start, 0.0, signed_arc_delta, arc_radius);
+        const auto   arc_points       = build_arc_points (start, 0.0, signed_arc_delta, arc_radius);
         if (arc_points.size () < 2) {
             continue;
         }
@@ -267,10 +264,10 @@ void steering_vector_visualizer::timer_callback () {
 
         marker_array_.markers.push_back (rotation_marker);
 
-        const geometry_msgs::msg::Point &arc_end = arc_points.back ();
-        const double arc_end_angle               = signed_arc_delta;
-        const double tangent_yaw                 = arc_end_angle + (direction >= 0 ? M_PI / 2.0 : -M_PI / 2.0);
-        const double arrow_length                = std::max (rotation_vector_line_width_ * 8.0, arc_radius * 0.85);
+        const geometry_msgs::msg::Point &arc_end       = arc_points.back ();
+        const double                     arc_end_angle = signed_arc_delta;
+        const double                     tangent_yaw   = arc_end_angle + (direction >= 0 ? M_PI / 2.0 : -M_PI / 2.0);
+        const double                     arrow_length  = std::max (rotation_vector_line_width_ * 8.0, arc_radius * 0.85);
 
         geometry_msgs::msg::Point arrow_start;
         arrow_start.x = arc_end.x - std::cos (tangent_yaw) * arrow_length;

--- a/src/visualization/natto_visualization_converter/src/swerve_visualizer.cpp
+++ b/src/visualization/natto_visualization_converter/src/swerve_visualizer.cpp
@@ -1,0 +1,306 @@
+// Copyright 2026 Kazusa Hashimoto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "natto_visualization_converter/swerve_visualizer.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iterator>
+#include <stdexcept>
+
+#include "tf2/utils.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+namespace steering_vector_visualizer {
+
+namespace {
+
+int find_index (const std::vector<std::string> &names, const std::string &name) {
+    const auto it = std::find (names.begin (), names.end (), name);
+    if (it == names.end ()) {
+        return -1;
+    }
+    return static_cast<int> (std::distance (names.begin (), it));
+}
+
+double normalize_angle (double angle) {
+    return std::atan2 (std::sin (angle), std::cos (angle));
+}
+
+std::vector<geometry_msgs::msg::Point> build_arc_points (
+    const geometry_msgs::msg::Point &center, double start_angle, double delta, double radius) {
+    const int segments = std::max (8, static_cast<int> (std::ceil (std::abs (delta) / (M_PI / 18.0))));
+    std::vector<geometry_msgs::msg::Point> points;
+    points.reserve (static_cast<size_t> (segments) + 1);
+
+    for (int i = 0; i <= segments; ++i) {
+        const double t     = static_cast<double> (i) / static_cast<double> (segments);
+        const double angle = start_angle + delta * t;
+
+        geometry_msgs::msg::Point point;
+        point.x = center.x + std::cos (angle) * radius;
+        point.y = center.y + std::sin (angle) * radius;
+        point.z = center.z;
+        points.push_back (point);
+    }
+
+    return points;
+}
+
+}  // namespace
+
+steering_vector_visualizer::steering_vector_visualizer (const rclcpp::NodeOptions &options) : Node ("steering_vector_visualizer", options) {
+    marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray> ("marker_array", 10);
+    joint_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState> ("command_joint_states", rclcpp::SensorDataQoS (), std::bind (&steering_vector_visualizer::joint_state_callback, this, std::placeholders::_1));
+
+    double frequency      = this->declare_parameter<double> ("frequency", 100.0);
+    chassis_type_         = this->declare_parameter<std::string> ("chassis_type", "");
+    wheel_radius_         = this->declare_parameter<double> ("wheel_radius", 0.05);
+    wheel_names_          = this->declare_parameter<std::vector<std::string>> ("wheel_names", {""});
+    wheel_base_names_     = this->declare_parameter<std::vector<std::string>> ("wheel_base_names", {""});
+    infinite_swerve_mode_ = this->declare_parameter<bool> ("infinite_swerve_mode", false);
+    frame_id_             = this->declare_parameter<std::string> ("frame_id", "command/base_link");
+    line_width_                 = this->declare_parameter<double> ("line_width", 0.05);
+    vector_scale_               = this->declare_parameter<double> ("vector_scale", 0.25);
+    rotation_vector_scale_      = this->declare_parameter<double> ("rotation_vector_scale", 0.12);
+    rotation_vector_line_width_ = this->declare_parameter<double> ("rotation_vector_line_width", 0.03);
+
+    tf_buffer_   = std::make_unique<tf2_ros::Buffer> (this->get_clock ());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener> (*tf_buffer_);
+
+    if (wheel_names_.size () != wheel_base_names_.size ()) {
+        throw std::runtime_error ("Invalid parameters: wheel_names and wheel_base_names size mismatch.");
+    }
+
+    steering_speeds_.assign (wheel_names_.size (), 0.0);
+    steering_speed_average_.assign (wheel_names_.size (), 0.0);
+    steering_speed_history_.assign (wheel_names_.size (), std::vector<double> (5, 0.0));
+    steering_speed_history_index_.assign (wheel_names_.size (), 0);
+    steering_speed_history_count_.assign (wheel_names_.size (), 0);
+    steering_speed_directions_.assign (wheel_names_.size (), 0);
+
+    RCLCPP_INFO (this->get_logger (), "steering_vector_visualizer node has been initialized.");
+    RCLCPP_INFO (this->get_logger (), "frequency: %.2f Hz", frequency);
+    RCLCPP_INFO (this->get_logger (), "chassis_type: %s", chassis_type_.c_str ());
+    if (chassis_type_ != "swerve") {
+        RCLCPP_WARN (this->get_logger (), "steering_vector_visualizer supports only swerve chassis_type. No markers will be published.");
+    }
+    RCLCPP_INFO (this->get_logger (), "wheel_radius: %.3f m", wheel_radius_);
+    RCLCPP_INFO (this->get_logger (), "frame_id: %s", frame_id_.c_str ());
+    RCLCPP_INFO (this->get_logger (), "line_width: %.3f", line_width_);
+    RCLCPP_INFO (this->get_logger (), "vector_scale: %.3f", vector_scale_);
+    RCLCPP_INFO (this->get_logger (), "rotation_vector_scale: %.3f", rotation_vector_scale_);
+    RCLCPP_INFO (this->get_logger (), "rotation_vector_line_width: %.3f", rotation_vector_line_width_);
+    RCLCPP_INFO (this->get_logger (), "infinite_swerve_mode: %s", infinite_swerve_mode_ ? "true" : "false");
+    RCLCPP_INFO (this->get_logger (), "num_wheels: %zu", wheel_names_.size ());
+
+    timer_ = this->create_wall_timer (std::chrono::duration<double> (1.0 / frequency), std::bind (&steering_vector_visualizer::timer_callback, this));
+}
+
+void steering_vector_visualizer::joint_state_callback (const sensor_msgs::msg::JointState::SharedPtr msg) {
+    // command_joint_states の連続差分を 5 サンプル平均して、低速域の符号反転を抑える。
+    if (has_previous_joint_state_) {
+        const rclcpp::Time current_stamp  (msg->header.stamp);
+        const rclcpp::Time previous_stamp (previous_joint_state_.header.stamp);
+        const double       dt             = (current_stamp - previous_stamp).seconds ();
+
+        if (dt > 1e-6) {
+            constexpr double direction_threshold = 0.25;
+            constexpr size_t history_length = 5;
+            for (size_t i = 0; i < wheel_base_names_.size (); ++i) {
+                const int current_idx  = find_index (msg->name, wheel_base_names_[i]);
+                const int previous_idx = find_index (previous_joint_state_.name, wheel_base_names_[i]);
+
+                if (
+                    current_idx < 0 || previous_idx < 0 ||
+                    static_cast<size_t> (current_idx) >= msg->position.size () ||
+                    static_cast<size_t> (previous_idx) >= previous_joint_state_.position.size ()) {
+                    continue;
+                }
+
+                const double current_angle = msg->position[static_cast<size_t> (current_idx)];
+                const double previous_angle = previous_joint_state_.position[static_cast<size_t> (previous_idx)];
+                const double raw_speed      = normalize_angle (current_angle - previous_angle) / dt;
+
+                steering_speeds_[i] = raw_speed;
+
+                auto &history = steering_speed_history_[i];
+                const size_t slot = steering_speed_history_index_[i];
+                history[slot] = raw_speed;
+                steering_speed_history_index_[i] = (slot + 1) % history_length;
+                steering_speed_history_count_[i] = std::min (steering_speed_history_count_[i] + 1, history_length);
+
+                double sum = 0.0;
+                for (size_t j = 0; j < history_length; ++j) {
+                    sum += history[j];
+                }
+                const double average_speed = sum / static_cast<double> (history_length);
+                steering_speed_average_[i] = average_speed;
+
+                if (std::abs (average_speed) >= direction_threshold) {
+                    steering_speed_directions_[i] = average_speed >= 0.0 ? 1 : -1;
+                } else {
+                    steering_speed_directions_[i] = 0;
+                    steering_speed_average_[i]    = 0.0;
+                }
+            }
+        }
+    }
+
+    previous_joint_state_     = *msg;
+    has_previous_joint_state_ = true;
+    joint_state_              = *msg;
+}
+
+void steering_vector_visualizer::timer_callback () {
+    marker_array_.markers.clear ();
+
+    if (chassis_type_ != "swerve") {
+        marker_pub_->publish (marker_array_);
+        return;
+    }
+
+    if (joint_state_.name.empty ()) {
+        marker_pub_->publish (marker_array_);
+        return;
+    }
+
+    for (size_t i = 0; i < wheel_names_.size (); ++i) {
+        const int wheel_idx     = find_index (joint_state_.name, wheel_names_[i]);
+        const int wheel_base_idx = find_index (joint_state_.name, wheel_base_names_[i]);
+
+        if (wheel_idx < 0 || static_cast<size_t> (wheel_idx) >= joint_state_.velocity.size ()) {
+            RCLCPP_WARN_THROTTLE (this->get_logger (), *this->get_clock (), 3000, "Could not find wheel joint: %s", wheel_names_[i].c_str ());
+            continue;
+        }
+
+        geometry_msgs::msg::TransformStamped tf_stamped;
+        try {
+            tf_stamped = tf_buffer_->lookupTransform (frame_id_, "command/" + wheel_base_names_[i] + "_link", tf2::TimePointZero);
+        } catch (tf2::TransformException &ex) {
+            RCLCPP_WARN_THROTTLE (this->get_logger (), *this->get_clock (), 3000, "Could not get transform for %s: %s", wheel_base_names_[i].c_str (), ex.what ());
+            continue;
+        }
+
+        const double steering_yaw = tf2::getYaw (tf_stamped.transform.rotation);
+        const double wheel_speed  = joint_state_.velocity[static_cast<size_t> (wheel_idx)] * wheel_radius_;
+        const double length       = wheel_speed * vector_scale_;
+
+        geometry_msgs::msg::Point start;
+        start.x = tf_stamped.transform.translation.x;
+        start.y = tf_stamped.transform.translation.y;
+        start.z = tf_stamped.transform.translation.z;
+
+        if (std::abs (length) >= 1e-6) {
+            geometry_msgs::msg::Point end;
+            end.x = start.x + std::cos (steering_yaw) * length;
+            end.y = start.y + std::sin (steering_yaw) * length;
+            end.z = start.z;
+
+            visualization_msgs::msg::Marker marker;
+            marker.header.frame_id = frame_id_;
+            marker.header.stamp    = this->now ();
+            marker.ns              = "steering_vector";
+            marker.id              = static_cast<int> (i);
+            marker.type            = visualization_msgs::msg::Marker::ARROW;
+            marker.action          = visualization_msgs::msg::Marker::ADD;
+            marker.lifetime        = rclcpp::Duration::from_seconds (0.5);
+            marker.scale.x         = line_width_;
+            marker.scale.y         = line_width_ * 2.0;
+            marker.scale.z         = line_width_ * 2.5;
+            marker.color.r         = 0.1f;
+            marker.color.g         = 0.8f;
+            marker.color.b         = 0.2f;
+            marker.color.a         = 1.0f;
+            marker.points          = {start, end};
+
+            marker_array_.markers.push_back (marker);
+        }
+
+        const bool has_target_steering = wheel_base_idx >= 0 && static_cast<size_t> (wheel_base_idx) < joint_state_.position.size ();
+        if (!has_target_steering) {
+            RCLCPP_WARN_THROTTLE (this->get_logger (), *this->get_clock (), 3000, "Could not find steering joint: %s", wheel_base_names_[i].c_str ());
+            continue;
+        }
+
+        const int direction = steering_speed_directions_[i];
+        if (direction == 0) {
+            continue;
+        }
+
+        const double steering_speed = steering_speed_average_[i];
+        const double speed_magnitude = std::max (std::abs (steering_speed), 0.35);
+        const double arc_radius = std::max (rotation_vector_scale_ * 1.8, rotation_vector_line_width_ * 5.0);
+        const double arc_delta   = std::clamp (speed_magnitude, 0.35, M_PI * 0.9);
+        const double signed_arc_delta = static_cast<double> (direction) * arc_delta;
+        const auto   arc_points = build_arc_points (start, 0.0, signed_arc_delta, arc_radius);
+        if (arc_points.size () < 2) {
+            continue;
+        }
+
+        visualization_msgs::msg::Marker rotation_marker;
+        rotation_marker.header.frame_id = frame_id_;
+        rotation_marker.header.stamp    = this->now ();
+        rotation_marker.ns              = "steering_speed_arc";
+        rotation_marker.id              = static_cast<int> (i);
+        rotation_marker.type            = visualization_msgs::msg::Marker::LINE_STRIP;
+        rotation_marker.action          = visualization_msgs::msg::Marker::ADD;
+        rotation_marker.lifetime        = rclcpp::Duration::from_seconds (0.5);
+        rotation_marker.scale.x         = rotation_vector_line_width_;
+        rotation_marker.color.r         = 0.95f;
+        rotation_marker.color.g         = 0.55f;
+        rotation_marker.color.b         = 0.15f;
+        rotation_marker.color.a         = 1.0f;
+        rotation_marker.points          = arc_points;
+
+        marker_array_.markers.push_back (rotation_marker);
+
+        const geometry_msgs::msg::Point &arc_end = arc_points.back ();
+        const double arc_end_angle               = signed_arc_delta;
+        const double tangent_yaw                 = arc_end_angle + (direction >= 0 ? M_PI / 2.0 : -M_PI / 2.0);
+        const double arrow_length                = std::max (rotation_vector_line_width_ * 8.0, arc_radius * 0.85);
+
+        geometry_msgs::msg::Point arrow_start;
+        arrow_start.x = arc_end.x - std::cos (tangent_yaw) * arrow_length;
+        arrow_start.y = arc_end.y - std::sin (tangent_yaw) * arrow_length;
+        arrow_start.z = arc_end.z;
+
+        visualization_msgs::msg::Marker arrow_marker;
+        arrow_marker.header.frame_id = frame_id_;
+        arrow_marker.header.stamp    = this->now ();
+        arrow_marker.ns              = "steering_speed_arc_head";
+        arrow_marker.id              = static_cast<int> (i + wheel_names_.size ());
+        arrow_marker.type            = visualization_msgs::msg::Marker::ARROW;
+        arrow_marker.action          = visualization_msgs::msg::Marker::ADD;
+        arrow_marker.lifetime        = rclcpp::Duration::from_seconds (0.5);
+        arrow_marker.scale.x         = rotation_vector_line_width_;
+        arrow_marker.scale.y         = rotation_vector_line_width_ * 3.0;
+        arrow_marker.scale.z         = rotation_vector_line_width_ * 3.8;
+        arrow_marker.color.r         = 0.95f;
+        arrow_marker.color.g         = 0.55f;
+        arrow_marker.color.b         = 0.15f;
+        arrow_marker.color.a         = 1.0f;
+        arrow_marker.points          = {arrow_start, arc_end};
+
+        marker_array_.markers.push_back (arrow_marker);
+    }
+
+    marker_pub_->publish (marker_array_);
+}
+
+}  // namespace steering_vector_visualizer
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE (steering_vector_visualizer::steering_vector_visualizer)


### PR DESCRIPTION

<img width="1920" height="1080" alt="Screenshot from 2026-06-24 07-28-52" src="https://github.com/user-attachments/assets/9c9da46a-73bc-4f60-b5f9-28cb0a4e5d3b" />

 追加したもの

  - natto_visualization_converter に、command_joint_states を可視化する swerve_visualizer を追加
  - RViz で見られるように、visualization_msgs/msg/MarkerArray を出力する構成を追加
  - visualization.launch.xml から起動できるように接続
  - RViz サンプル設定に表示項目を追加
  - 説明ドキュメントを追加・更新

  追加した CPP / ヘッダ

  - 追加した CPP: src/visualization/natto_visualization_converter/src/swerve_visualizer.cpp
  - 追加したヘッダ: src/visualization/natto_visualization_converter/include/natto_visualization_converter/swerve_visualizer.hpp

  追加した機能

  - 各ホイールの車輪速度を緑の矢印で表示
  - 各ホイールのステア角速度をオレンジの円弧状矢印で表示
  - ステア角速度は、車体前方 0° を始点にした共通の円弧表現に統一
  - ステア速には軽い平滑化を適用
  - 平滑化量は使う側が調整できるようにパラメータ化

  トピック構成

  - 入力
      - command_joint_states
      - 型: sensor_msgs/msg/JointState
      - 役割: ステア角と車輪速度の元データ
      - launch では /$(var chassis_type)/command_joint_states を remap

  - 出力
      - marker_array
      - 型: visualization_msgs/msg/MarkerArray
      - 役割: RViz 表示用マーカー
      - launch では /visualization/steering_vector に remap

  ステア速の見え方に関係するパラメータ

  - steering_speed_history_length
      - 履歴平均に使うサンプル数
      - 大きいほど安定、小さいほど反応が速い
      - デフォルト: 5

  - steering_speed_render_alpha
      - 描画側の追従量
      - 大きいほど表示がすぐ追従し、小さいほど残像が長くなる
      - デフォルト: 0.16

  注意点

  - 平滑化の影響で表示は実際の変化から少し遅れて見える
  - 値のズレが気になる場合は steering_speed_history_length と steering_speed_render_alpha を調整する

  既存の表示調整パラメータ

  - wheel_radius
      - 車輪速度のスケールに使用

  - vector_scale
      - 車輪速度矢印の長さ調整

  - rotation_vector_scale
      - ステア速円弧の半径調整

  - rotation_vector_line_width
      - ステア速円弧と矢印の太さ調整

  - line_width
      - 車輪速度矢印の太さ調整

  - frame_id
      - 描画基準フレーム

  - frequency
      - マーカー更新周期

  - chassis_type
      - swerve のときのみ有効

  - wheel_names
      - 車輪ジョイント名

  - wheel_base_names
      - ステアジョイント名

  - infinite_swerve_mode
      - chassis_calculator 互換の設定

  使い方

  1. visualization.launch.xml を起動する
  2. chassis_type を swerve にする
  3. wheel_names と wheel_base_names を実機のジョイント名に合わせる
  4. command_joint_states が流れてくることを確認する
  5. RViz で /visualization/steering_vector の MarkerArray を表示する

  平滑化の調整例

  - もっとなめらかにしたい
      - steering_speed_history_length を増やす

  - もっと素早く追従させたい
      - steering_speed_history_length を減らす
      - steering_speed_render_alpha を上げる

  - 残像を短くしたい
      - steering_speed_render_alpha を上げる

  - 低速域を落ち着いて見せたい
      - steering_speed_render_alpha を少し下げる

  launch からの上書き例

  ros2 launch natto_launch visualization.launch.xml steering_speed_history_length:=3 steering_speed_render_alpha:=0.25

  変更した主なファイル

  - src/visualization/natto_visualization_converter/src/swerve_visualizer.cpp
  - src/visualization/natto_visualization_converter/include/natto_visualization_converter/swerve_visualizer.hpp
  - src/launch/natto_launch/launch/components/visualization.launch.xml
  - docs/visualization/natto_visualization_converter.md